### PR TITLE
fix #29: Accept line comment ending in EOF

### DIFF
--- a/lib/parser/Lex.mll
+++ b/lib/parser/Lex.mll
@@ -81,7 +81,7 @@ let type =
 
 (* Whitespace/comments *)
 rule line_comment kont = parse
-  | line_ending
+  | line_ending | eof
     { new_line lexbuf; kont lexbuf }
   | _
     { line_comment kont lexbuf }


### PR DESCRIPTION
(If there is no newline at end of file)