### PR TITLE
feat: tail for Lists, some goodies for Nats

### DIFF
--- a/std-lib/Data/Natural.poly
+++ b/std-lib/Data/Natural.poly
@@ -4,10 +4,50 @@ def add : ℕ → ℕ → ℕ :=
 def mul : ℕ → ℕ → ℕ :=
   λ m n → elim (λ _ → ℕ) 0 (λ _ x → add n x) m
 
+def pred : ℕ → ℕ :=
+  λ n → elim (λ _ → ℕ) 0 (λ m _ → m) n
+
 def ℕ-elim :
   Π (mot : ℕ → Type),
   { .zero : mot zero
   , .succ : Π (n : ℕ), mot n → mot (succ n)
   } →
   Π (n : ℕ), mot n :=
-  λ mot r n → elim mot (r .zero) (r .succ) n
+  λ mot cases n → elim mot (cases .zero) (cases .succ) n
+
+def ℕ-rec :
+  Π (mot : Type),
+  { .zero : mot
+  , .succ : mot → mot
+  } → ℕ → mot :=
+  λ mot cases → ℕ-elim (λ _ → mot)
+    { .zero = cases .zero
+    , .succ = λ _ → cases .succ
+    }
+
+def ℕ-switch :
+  Π (mot : Type),
+  { .zero : mot
+  , .succ : mot
+  } → ℕ → mot :=
+  λ mot cases →
+    ℕ-rec mot
+      { .zero = cases .zero
+      , .succ = λ _ → cases .succ
+      }
+
+def ℕ-name : ℕ → #{ .zero, .succ } :=
+  -- FIXME(Verity)
+  -- ℕ-switch #{ .zero, .succ } (λ name → name)
+  ℕ-switch #{ .zero, .succ } { .zero = .zero, .succ = .succ }
+
+def ℕ-cases :
+  Π (mot : ℕ → Type),
+  { .zero : mot 0
+  , .succ : Π (n : ℕ), mot (succ n)
+  } → Π (n : ℕ), mot n :=
+  λ mot cases →
+    ℕ-elim mot
+      { .zero = cases .zero
+      , .succ = λ n _ → cases .succ n
+      }

--- a/std-lib/Data/Polynomial/List.poly
+++ b/std-lib/Data/Polynomial/List.poly
@@ -27,6 +27,15 @@ def List-rec : Π (A : Type) (mot : Type),
         }
       )
 
+def tail : Π (A : Type), List A → List A :=
+  λ A →
+    ×-rec ℕ (λ n → fin n → A) (λ _ → List A)
+      (ℕ-cases (λ n → (fin n → A) → List A)
+        { .zero = λ _ → nil A
+        , .succ = λ n as → (n , λ i → as (s n i))
+        }
+      )
+
 --------------------------------------------------------------------------------
 -- Examples
 


### PR DESCRIPTION
I implemented a way to case on nats and used it to implement tail on lists pretty directly:
- if it's length zero, we don't care and return nil
- if it's length (succ n), we make a list of length n by doing the obvious tail operation (calling succ on the passed index, before handing it to the original vector)