### PR TITLE
fix: Correctly update spans in tactics

### DIFF
--- a/lib/elab/Elaborator.ml
+++ b/lib/elab/Elaborator.ml
@@ -10,7 +10,7 @@ module T = Tactic
 module Internal =
 struct
   let rec chk (tm : CS.t) =
-    T.Error.locate tm.loc @@ fun () ->
+    T.Chk.locate tm.loc @@
     match tm.node with
     | CS.Lam (names, tm) ->
       chk_lams names tm
@@ -44,7 +44,7 @@ struct
       T.Chk.syn (syn tm)
 
   and neg_chk (tm : CS.t) =
-    T.Error.locate tm.loc @@ fun () ->
+    T.NegChk.locate tm.loc @@
     match tm.node with
     | CS.NegPair (a, name, b) ->
       NegSigma.intro (neg_chk a) ~name (fun _ -> neg_chk b)
@@ -77,7 +77,7 @@ struct
     T.Syn.ann (chk b) (T.Chk.syn Univ.formation)
 
   and syn (tm : CS.t) =
-    T.Error.locate tm.loc @@ fun () ->
+    T.Syn.locate tm.loc @@
     match tm.node with
     | CS.Var path ->
       syn_var path
@@ -135,7 +135,7 @@ struct
       T.Error.error `RequiresAnnotation "Term requires an annotation."
 
   and neg_syn (tm : CS.t) =
-    T.Error.locate tm.loc @@ fun () ->
+    T.NegSyn.locate tm.loc @@
     match tm.node with
     | CS.Var path ->
       begin
@@ -157,7 +157,7 @@ struct
       T.Error.error `TypeError "Cannot synthesize (negative) type."
 
   and hom (tm : CS.t) =
-    T.Error.locate tm.loc @@ fun () ->
+    T.Hom.locate tm.loc @@
     match tm.node with
     | Set (pos, neg, steps) ->
       Hom.set (chk pos) (neg_syn neg) (hom steps)
@@ -175,7 +175,7 @@ struct
       T.Error.error `NotAHom "Cannot be used to build a hom."
 
   and prog (tm : CS.t) =
-    T.Error.locate tm.loc @@ fun () ->
+    T.Prog.locate tm.loc @@
     match tm.node with
     | Set (pos, neg, steps) ->
       Prog.set (chk pos) (neg_syn neg) (prog steps)

--- a/std-lib/Data/Natural.poly
+++ b/std-lib/Data/Natural.poly
@@ -7,6 +7,12 @@ def mul : ℕ → ℕ → ℕ :=
 def pred : ℕ → ℕ :=
   λ n → elim (λ _ → ℕ) 0 (λ m _ → m) n
 
+
+def foo : ℕ :=
+  add 1 (add 2 Type)
+
+#quit
+
 def ℕ-elim :
   Π (mot : ℕ → Type),
   { .zero : mot zero

--- a/std-lib/Data/Natural.poly
+++ b/std-lib/Data/Natural.poly
@@ -7,12 +7,6 @@ def mul : ℕ → ℕ → ℕ :=
 def pred : ℕ → ℕ :=
   λ n → elim (λ _ → ℕ) 0 (λ m _ → m) n
 
-
-def foo : ℕ :=
-  add 1 (add 2 Type)
-
-#quit
-
 def ℕ-elim :
   Π (mot : ℕ → Type),
   { .zero : mot zero


### PR DESCRIPTION
This fixes an annoying issue where conversion checker errors would cause the entire term to be highlighted.