### PR TITLE
Fixes line breaks in ConversionError pretty printer

### DIFF
--- a/lib/refiner/Eff.ml
+++ b/lib/refiner/Eff.ml
@@ -420,7 +420,7 @@ let equate ~tp v1 v2 =
     let tm1 = Quote.quote ~env ~tp v1 in
     let tm2 = Quote.quote ~env ~tp v2 in
     Debug.print "Unequal:@.%a@.%a@." S.dump tm1 S.dump tm2;
-    Error.error `ConversionError "Could not solve %a = %a@."
+    Error.error `ConversionError "@[<v 2>Could not solve:@ @[<v>%a@] = @[<v>%a@]@]"
       (S.pp ppenv (Precedence.left_of S.equals)) tm1
       (S.pp ppenv (Precedence.right_of S.equals)) tm2
 


### PR DESCRIPTION
with big errors:
```
     █ [E006] Could not solve:
              Σ (<5> : Σ (<2183> : B), B), Σ (<2184> : C), C ⇒ Σ (<5> : Σ (<2185> : B), A), Σ (<2186> : C), B = 
              Σ (<2> : Σ (<1914> : B), C), Σ (<1915> : B), C ⇒ Σ (<2> : Σ (<1914> : B), C), Σ (<1915> : A), B

```

with small errors:
```
     █ [E006] Could not solve:
              Σ (<6> : C), B ⇒ Σ (<6> : C), B = Σ (<3> : C), C ⇒ Σ (<3> : C), B

```